### PR TITLE
Fix todo form mapping

### DIFF
--- a/api/src/main/java/com/example/api/controller/ToDoForm.java
+++ b/api/src/main/java/com/example/api/controller/ToDoForm.java
@@ -1,9 +1,10 @@
 package com.example.api.controller;
 
-import java.util.List;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 //フォームで送られてきた入力内容を、一時的にまとめて受け取るための入れ物（データの箱）
 public class ToDoForm {
     public String title;
+    @JsonProperty("is_completed")
     public Boolean isCompleted;
 }

--- a/client/src/app/todo-list/page.tsx
+++ b/client/src/app/todo-list/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 // フォーム型、型きめ
 type ToDoForm = {
   title: string;
@@ -21,11 +21,9 @@ export default function ContactPage() {
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
   ) => {
-    // 変更があったフォーム要素からname, value, typeを取得
-    const { name, value, type } = e.target;
-    {
-      setForm(prev => ({ ...prev, [name]: value }));
-    }
+    // 変更があったフォーム要素からname, valueを取得
+    const { name, value } = e.target;
+    setForm(prev => ({ ...prev, [name]: value }));
   };
 
 
@@ -53,7 +51,7 @@ export default function ContactPage() {
 
     try {
       // サーバーAPIにPOSTリクエストでデータ送信
-      const res = await fetch("http://localhost:8080/api/todos", {
+      const res = await fetch("http://localhost:80/api/todos", {
         method: "POST",
         headers: { "Content-Type": "application/json" }, // JSON形式で送る
         body: JSON.stringify(sendData), // データをJSON文字列に変換して送信


### PR DESCRIPTION
## Summary
- map incoming JSON field `is_completed` to the Todo form
- update todo-list page to send requests to port 80
- fix eslint errors on todo-list page

## Testing
- `npm install`
- `npm run lint`
- `npm run build`
- `./mvnw test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683fe3d3f3108328aaf7dc3f57454745