### PR TITLE
Align is_completed field names

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -15,11 +15,16 @@ paths:
               type: object
               required:
                 - title
+                - is_completed
               properties:
                 title:
                   type: string
                   example: "くまおさんに連絡する"
                   description: "TODOのタイトル"
+                is_completed:
+                  type: boolean
+                  example: false
+                  description: "TODOの完了状態"
       responses:
         '201':
           description: TODO created successfully

--- a/api/src/main/java/com/example/api/controller/ToDoForm.java
+++ b/api/src/main/java/com/example/api/controller/ToDoForm.java
@@ -1,9 +1,11 @@
 package com.example.api.controller;
 
-import java.util.List;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 //フォームで送られてきた入力内容を、一時的にまとめて受け取るための入れ物（データの箱）
 public class ToDoForm {
     public String title;
+
+    @JsonProperty("is_completed")
     public Boolean isCompleted;
 }


### PR DESCRIPTION
## Summary
- map `isCompleted` to `is_completed` in `ToDoForm`
- document POST /todos to accept `is_completed`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe67de8cc8328a37e2822393eaedd