### PR TITLE
Complete TODO API and frontend

### DIFF
--- a/api/src/main/java/com/example/api/controller/SubmitTodoController.java
+++ b/api/src/main/java/com/example/api/controller/SubmitTodoController.java
@@ -2,11 +2,12 @@ package com.example.api.controller;
 
 import com.example.api.entity.Todo;
 import com.example.api.repository.TodoRepository;
+import com.example.api.controller.UpdateTodoForm;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.sql.Timestamp;
+import java.util.List;
 
 //API用コントローラ-,フロントからのリクエストを受け付ける
 @RestController
@@ -30,6 +31,31 @@ public class SubmitTodoController {
         todoRepository.save(todos);
 
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/api/todos")
+    public List<Todo> list() {
+        return todoRepository.findAll();
+    }
+
+    @PutMapping("/api/todos/{id}")
+    public ResponseEntity<?> update(@PathVariable Long id, @RequestBody UpdateTodoForm form) {
+        return todoRepository.findById(id)
+                .map(todo -> {
+                    todo.setIsCompleted(form.isCompleted);
+                    todoRepository.save(todo);
+                    return ResponseEntity.ok().build();
+                })
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/api/todos/{id}")
+    public ResponseEntity<?> delete(@PathVariable Long id) {
+        if (todoRepository.existsById(id)) {
+            todoRepository.deleteById(id);
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.notFound().build();
     }
 }
 

--- a/api/src/main/java/com/example/api/controller/UpdateTodoForm.java
+++ b/api/src/main/java/com/example/api/controller/UpdateTodoForm.java
@@ -1,0 +1,8 @@
+package com.example.api.controller;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class UpdateTodoForm {
+    @JsonProperty("is_completed")
+    public Boolean isCompleted;
+}

--- a/api/src/main/java/com/example/api/entity/Todo.java
+++ b/api/src/main/java/com/example/api/entity/Todo.java
@@ -3,9 +3,9 @@ package com.example.api.entity;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.Data;
-import java.sql.Timestamp;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 
 
@@ -20,6 +20,7 @@ public class Todo {
     private String title;
 
     @Column(name = "is_completed")
+    @JsonProperty("is_completed")
     private Boolean isCompleted;
 
     @Column(name = "created_at")

--- a/api/src/test/java/com/example/api/SubmitTodoControllerTests.java
+++ b/api/src/test/java/com/example/api/SubmitTodoControllerTests.java
@@ -12,6 +12,7 @@ import org.springframework.http.*;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -46,5 +47,53 @@ class SubmitTodoControllerTests {
         assertThat(todoRepository.count()).isEqualTo(1);
         Todo todo = todoRepository.findAll().get(0);
         assertThat(todo.getTitle()).isEqualTo("test todo");
+    }
+
+    @Test
+    void getTodos_shouldReturnPersistedTodos() {
+        Todo todo = new Todo();
+        todo.setTitle("task");
+        todo.setIsCompleted(false);
+        todoRepository.save(todo);
+
+        ResponseEntity<Todo[]> response = restTemplate.getForEntity("/api/todos", Todo[].class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(1);
+        assertThat(response.getBody()[0].getTitle()).isEqualTo("task");
+    }
+
+    @Test
+    void updateTodo_shouldChangeCompletionStatus() {
+        Todo todo = new Todo();
+        todo.setTitle("task");
+        todo.setIsCompleted(false);
+        todoRepository.save(todo);
+
+        Map<String, Object> request = new HashMap<>();
+        request.put("is_completed", true);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(request, headers);
+
+        ResponseEntity<Void> response = restTemplate.exchange("/api/todos/" + todo.getId(), HttpMethod.PUT, entity, Void.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        Todo updated = todoRepository.findById(todo.getId()).orElseThrow();
+        assertThat(updated.getIsCompleted()).isTrue();
+    }
+
+    @Test
+    void deleteTodo_shouldRemoveTodo() {
+        Todo todo = new Todo();
+        todo.setTitle("task");
+        todo.setIsCompleted(false);
+        todoRepository.save(todo);
+
+        ResponseEntity<Void> response = restTemplate.exchange("/api/todos/" + todo.getId(), HttpMethod.DELETE, null, Void.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        assertThat(todoRepository.existsById(todo.getId())).isFalse();
     }
 }


### PR DESCRIPTION
## Summary
- expose full CRUD endpoints in `SubmitTodoController`
- return JSON property `is_completed` from `Todo` entity
- add form object for updating todo status
- expand backend tests for list, update, and delete
- enhance front-end to list, toggle, and delete todos

## Testing
- `mvn test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683fe8c57f0483289e601e7cc677f706